### PR TITLE
Fix README test file references

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ rust-barrier/
 │ ├── network/ (handles computer communication)
 │ └── lib.rs (ties everything together)
 └── tests/
-├── event_tests.rs (makes sure events work)
-└── network_tests.rs (makes sure computers talk)
+├── event_unit_tests.rs (makes sure events work)
+└── network_integration_tests.rs (makes sure computers talk)
 
 ## Next Steps
 - Add Linux X11 support


### PR DESCRIPTION
## Summary
- update test filenames in project structure section

## Testing
- `cargo test` *(fails: could not compile `rust-barrier`)*

------
https://chatgpt.com/codex/tasks/task_e_68401a9f42c88322b5b0b0a1047e9432